### PR TITLE
Add Option to Disable CSV Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A Gitbook plugin for including and rending CSV file in your book.
 
 ## How to install it?
-You can install via NPM: 
+You can install via NPM:
 
 ```sh
 $ npm install --save gitbook-plugin-include-csv
@@ -45,6 +45,7 @@ b,002
 | name      | description                           | example           |
 |-----------|---------------------------------------|-------------------|
 | src       | The file path for including CSV file. | "./filename.csv"  |
+| linkSrc   | Link to CSV file above the table.     | "true"            |
 | encoding  | character encoding in CSV file.       | "shift_jis"       |
 | useHeader | use 1st row for header.               | "true"            |
 | exHeaders | define column headers.                | "col01,col02"     |
@@ -74,8 +75,8 @@ c1,c2,c3
 Show the table from csv file, define column headers directory, set limit of rows.
 
 ```
-{% includeCsv 
-    src="./train.1.csv", 
+{% includeCsv
+    src="./train.1.csv",
     exHeaders="PassengerId,Survived,Pclass,Name,Sex,Age,SibSp,Parch,Ticket,Fare,Cabin,Embarked",
     limit=2 %}
 {% endincludeCsv %}

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = {
             process: function(blk) {
                 const tagBody = blk.body;
                 const tagSrc = blk.kwargs.src;
+                const linkSrc = (blk.kwargs.linkSrc || true) === true;
                 const useHeader = blk.kwargs.useHeader || false;
                 const encoding = blk.kwargs.encoding || null;
                 const exHeaders = blk.kwargs.exHeaders || null;
@@ -65,7 +66,8 @@ module.exports = {
                 }
                 let table = buildTable(csvData, useHeader, exHeaders); // build table html tags
                 if (tagSrc) {
-                    table = "<a href=\"/" + relativeSrcPath + "\" target=\"_blank\">" + tagSrc + "</a>" + table;
+                  const link = linkSrc ? `<a href="${relativeSrcPath}" target="_blank">${tagSrc}</a>` : "";
+                  table = `${link} ${table}`;
                 }
                 return table;
             }


### PR DESCRIPTION
Thanks for this plugin, very useful. In my use case I'd like to turn off the link above the table. 

I've added a `linkSrc` option, that defaults to `true` for backwards compatibility. 

```
{% includeCsv src="./props.csv", linkSrc="false" %}{% endincludeCsv %}
```